### PR TITLE
chore(deps): Using tsc -b --clean instead of rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6785,7 +6785,6 @@
         "@types/jest": "27.0.3",
         "@types/lodash": "4.14.181",
         "jest": "27.4.3",
-        "rimraf": "3.0.2",
         "ts-jest": "27.0.7",
         "typescript": "4.4.3"
       }
@@ -6800,7 +6799,6 @@
       "devDependencies": {
         "@types/jest": "27.0.3",
         "jest": "27.4.3",
-        "rimraf": "3.0.2",
         "ts-jest": "27.0.7",
         "typescript": "4.4.3"
       }
@@ -6810,7 +6808,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "rimraf": "3.0.2",
         "typescript": "4.4.3"
       }
     }
@@ -7630,7 +7627,6 @@
         "@types/lodash": "4.14.181",
         "jest": "27.4.3",
         "lodash": "^4.17.15",
-        "rimraf": "3.0.2",
         "ts-jest": "27.0.7",
         "typescript": "4.4.3"
       }
@@ -7641,7 +7637,6 @@
         "@kesin11/monorepo-sandbox-types": "^1.0.0",
         "@types/jest": "27.0.3",
         "jest": "27.4.3",
-        "rimraf": "3.0.2",
         "ts-jest": "27.0.7",
         "typescript": "4.4.3"
       }
@@ -7649,7 +7644,6 @@
     "@kesin11/monorepo-sandbox-types": {
       "version": "file:packages/types",
       "requires": {
-        "rimraf": "3.0.2",
         "typescript": "4.4.3"
       }
     },

--- a/packages/consumer/package.json
+++ b/packages/consumer/package.json
@@ -22,7 +22,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf dist",
+    "clean": "tsc -b --clean",
     "test": "jest"
   },
   "dependencies": {
@@ -34,7 +34,6 @@
     "@types/jest": "27.0.3",
     "@types/lodash": "4.14.181",
     "jest": "27.4.3",
-    "rimraf": "3.0.2",
     "ts-jest": "27.0.7",
     "typescript": "4.4.3"
   },

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -22,13 +22,12 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf dist",
+    "clean": "tsc -b --clean",
     "test": "jest"
   },
   "devDependencies": {
     "@types/jest": "27.0.3",
     "jest": "27.4.3",
-    "rimraf": "3.0.2",
     "ts-jest": "27.0.7",
     "typescript": "4.4.3"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,11 +24,10 @@
   ],
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf dist",
+    "clean": "tsc -b --clean",
     "test": "tsc -b"
   },
   "devDependencies": {
-    "rimraf": "3.0.2",
     "typescript": "4.4.3"
   },
   "gitHead": "46206344dfc394d00692027aa291d85977732448"


### PR DESCRIPTION
Also `tsc -b --clean` remove `dist` dir that generated by `tsc -b` so rimraf is no longer needed.