### PR TITLE
chore(ci): Bump nodejs versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
       with:
         node-version: "lts/*"
         cache: 'npm'
-    - run: |
-        npm i -g npm
-        npm ci
+    - run: npm ci
     # Run
     - run: npm run lint
     - run: npm run reference -- --check
@@ -21,7 +19,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-versions: ["14", "16"]
+        node-versions: ["16", "18"]
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -32,10 +30,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-versions }}
         cache: 'npm'
-    # NOTE: npm workspace support from npm 7, so need to update npm when using nodejs 14
-    - run: |
-        npm i -g npm
-        npm ci
+    - run: npm ci
     - name: "Show version"
       run: |
         node --version

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -17,9 +17,7 @@ jobs:
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
-      - run: |
-          npm i -g npm
-          npm ci
+      - run: npm ci
       - run: npm run release:trigger
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "4.4.3"
       },
       "engines": {
-        "npm": ">=7.0.0"
+        "npm": ">=8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "engines": {
-    "npm": ">=7.0.0"
+    "npm": ">=8.0.0"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
nodejs 18 is released.
Bundled npm version is > 8 from nodejs 16, so remove code that updating npm inside CI.