### PR TITLE
fix: Invalid monorepo dependencies versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ lerna publish from-package
 #### バージョンの書き換え
 `npm version -ws major` のように `npm verson` を実行すると全パッケージのバージョンを上げてくれる。昔はpackage-lock.jsonまでは更新していなかった気がするがいつの間にか同時に更新されるようになっていた。ただし、monorepoの各パッケージが互いに依存している場合にそれぞれの `dependencies` のバージョンまでは上げてくれない。`^1.0.0` の指定の場合はpatchとminorまでは問題ないがmajorを上げるときに `npm install` がエラーになってしまう。
 
-majorのときに手動で修正が必要になるのを避けるため、バージョン指定を `"*"` にすることで制約を無しにしておく。workspaceを使っている場合はmonorepoのパッケージを参照するように `npm install` されるので多分問題はないはず。
+majorのときに手動で修正が必要になるのを避けるため、バージョン指定を `"*"` にすることで制約を無しにしておく。workspaceを使っている場合はmonorepoのパッケージを参照するように `npm install` されるので多分問題はないはず。参照できているかどうかは `npm ls` で確認できる。
 
 #### リリース作業
 リリース作業は手動（workflow_dispatch）+ [release-drafter](https://github.com/marketplace/actions/release-drafter)で行う。release-drafterはGithub Releasesの作成とSemantic Versioningに基づく次バージョンの文字列を自動生成してくれるので、次バージョンの文字列を使用して `npm version` でバージョンを更新する。

--- a/packages/consumer/package.json
+++ b/packages/consumer/package.json
@@ -28,8 +28,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@kesin11/monorepo-sandbox-provider": "^1.0.0",
-    "@kesin11/monorepo-sandbox-types": "^1.0.0",
+    "@kesin11/monorepo-sandbox-provider": "*",
+    "@kesin11/monorepo-sandbox-types": "*",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -34,7 +34,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@kesin11/monorepo-sandbox-types": "^1.0.0"
+    "@kesin11/monorepo-sandbox-types": "*"
   },
   "gitHead": "46206344dfc394d00692027aa291d85977732448"
 }


### PR DESCRIPTION
https://github.com/Kesin11/monorepo-typescript-sandbox/blob/c77db781701396b425c9f64fb61e5453d36ba629/README.md?plain=1#L91

> majorのときに手動で修正が必要になるのを避けるため、バージョン指定を `"*"` にすることで制約を無しにしておく。